### PR TITLE
Fixed segfault when from project has no milestones

### DIFF
--- a/cmd/gitlab-copy/stats.go
+++ b/cmd/gitlab-copy/stats.go
@@ -67,7 +67,7 @@ func (p *projectStats) computeStats(client *gitlab.Client) error {
 				case "closed":
 					p.nbClosed++
 				}
-				if issue.Milestone.Title != "" {
+				if issue.Milestone!=nil && issue.Milestone.Title != "" {
 					p.milestones[issue.Milestone.Title]++
 				}
 			}


### PR DESCRIPTION
Added check for nil milestones, which was causing segfault when copying from projects with no defined milestones